### PR TITLE
feat: propagate exit codes, keep stdin interactive, add task params/aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,10 +868,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1437,15 +1451,16 @@ dependencies = [
 
 [[package]]
 name = "mq-lang"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1212fc83c06eef62bf76ccea314ae51cfa72304bd73445bae64960281835c229"
+checksum = "73c5f80180e33e9278a38894b864270f8cacc342a5586cbf7fd9c8e108aa07a8"
 dependencies = [
  "base64",
  "chrono",
  "ciborium",
  "csv",
  "dirs",
+ "getrandom 0.4.2",
  "hcl-rs",
  "itertools 0.15.0",
  "md5",
@@ -1456,6 +1471,7 @@ dependencies = [
  "nom_locate",
  "percent-encoding",
  "quick-xml",
+ "rand 0.10.2",
  "regex-lite",
  "rustc-hash",
  "serde",
@@ -1469,15 +1485,16 @@ dependencies = [
  "toml",
  "toon-format",
  "url",
+ "uuid",
  "web-sys",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "mq-macros"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e8b069c44f6802457aac42a52b2a44953b55b128ad1cfd7960d263bb3a318d"
+checksum = "b5ad779e5b5fa43841cad4ce8eb88b58d32c34e26bdd92a1bc0d1048b1d96874"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1486,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "mq-markdown"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2cc321c5808b511b9b06ffb67b504ee6128a064cabfef16a2a0994ea8dce25"
+checksum = "2494d260b43ba34a8243e1fe3f836776c1287638fa0e5e3347dca6a8dab869fd"
 dependencies = [
  "ego-tree",
  "itertools 0.15.0",
@@ -1496,13 +1513,15 @@ dependencies = [
  "miette",
  "rustc-hash",
  "scraper",
+ "serde",
+ "serde_json",
  "serde_yaml",
  "smol_str",
 ]
 
 [[package]]
 name = "mq-task"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "clap",
  "colored",
@@ -1788,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1899,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1933,7 +1952,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1941,6 +1971,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2813,9 +2849,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "mq-task"
 readme = "README.md"
 repository = "https://github.com/harehare/mq"
-version = "0.1.13"
+version = "0.1.14"
 
 [[bin]]
 name = "mq-task"
@@ -24,8 +24,8 @@ clap = {version = "4.6.1", features = ["derive"]}
 colored = "3.1"
 crossterm = "0.29"
 miette = {version = "7.6.0", features = ["fancy"]}
-mq-lang = "0.6.2"
-mq-markdown = "0.6.2"
+mq-lang = "0.6.5"
+mq-markdown = "0.6.5"
 ratatui = "0.30"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-<h1 align="center">mq-task</h1>
+<div align="center">
+  <img src="assets/logo.svg" width="96" height="96" alt="mq-task logo" />
 
-[![ci](https://github.com/harehare/mq-task/actions/workflows/ci.yml/badge.svg)](https://github.com/harehare/mq-task/actions/workflows/ci.yml)
+  <h1>mq-task</h1>
+
+[![ci](https://img.shields.io/github/actions/workflow/status/harehare/mq-task/ci.yml?style=flat-square&logo=github-actions&label=ci)](https://github.com/harehare/mq-task/actions/workflows/ci.yml)
+[![release](https://img.shields.io/github/v/release/harehare/mq-task?style=flat-square&logo=github&label=release)](https://github.com/harehare/mq-task/releases)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
+
+</div>
 
 `mq-task` is a task runner that executes code blocks in Markdown files based on section titles.
 It is implemented using [mq](https://github.com/harehare/mq), a jq-like command-line tool for Markdown processing, to parse and extract sections from Markdown documents.
@@ -14,7 +21,9 @@ It is implemented using [mq](https://github.com/harehare/mq), a jq-like command-
 
 - Execute code blocks from specific sections in Markdown files
 - Task dependencies with automatic execution ordering
-- Configurable runtimes for different programming languages
+- Named task parameters with defaults, plus positional args
+- Default task, aliases, and private (hidden) tasks
+- Configurable runtimes for different programming languages, with real exit codes and interactive stdin
 - Support for custom heading levels
 - TOML-based configuration
 - Built on top of the mq query language
@@ -138,6 +147,64 @@ Running dependency: lint
 - Shared dependencies are executed only once even if multiple tasks depend on them
 - Circular dependencies are detected and reported as an error
 
+### Named parameters
+
+Declare parameters in the `meta` block. A bare name is required; `name=value` sets a default.
+
+````markdown
+## deploy
+
+```meta
+params = ["env=staging", "region"]
+```
+
+```bash
+echo "deploying to $MX_PARAM_ENV / $MX_PARAM_REGION"
+```
+````
+
+```bash
+mq-task deploy -- region=eu           # env falls back to "staging"
+mq-task deploy -- prod eu             # positional, filled in declaration order
+mq-task deploy -- env=prod region=eu  # named
+```
+
+Parameters are exposed as `MX_PARAM_<NAME>` environment variables. A required parameter with no value bound is an error.
+
+### Aliases and the default task
+
+Give a task alternate names with `alias` in its `meta` block:
+
+````markdown
+## build
+
+```meta
+alias = ["b"]
+```
+
+```bash
+cargo build
+```
+````
+
+`mq-task b` now runs `build`. Set `default_task` in `mq-task.toml` to run a task when `mq-task` is invoked with no task name:
+
+```toml
+default_task = "build"
+```
+
+### Private tasks
+
+A task whose title starts with `_`, or whose `meta` block has `private = true`, is hidden from `list`/`tui` output but can still be run directly or used as a dependency:
+
+````markdown
+## _cleanup
+
+```bash
+rm -rf tmp/
+```
+````
+
 ### List available tasks
 
 ```bash
@@ -147,6 +214,9 @@ mq-task
 # List tasks from a specific file
 mq-task -f tasks.md
 mq-task list --file tasks.md
+
+# Include private tasks
+mq-task list --all
 ```
 
 ### Initialize configuration
@@ -163,8 +233,7 @@ Create an `mq-task.toml` file to customize runtime behavior:
 
 ```toml
 # Runtimes configuration
-# Simple format: language = "command"
-# The execution mode defaults to "stdin"
+# Simple format: language = "command", execution mode defaults to "file"
 [runtimes]
 bash = "bash"
 sh = "sh"
@@ -175,32 +244,33 @@ javascript = "node"
 js = "node"
 php = "php"
 perl = "perl"
-jq = "jq"
 
 # Detailed format with execution mode
-# Execution modes: "stdin" (default), "file", or "arg"
-# - stdin: Pass code via standard input
-# - file: Write code to a temporary file and pass it as an argument
-# - arg: Pass code as a command-line argument
+# Execution modes: "file" (default), "stdin", or "arg"
+# - file: write code to a temp file and run it as an argument (keeps stdin interactive)
+# - stdin: pipe code into the command's standard input (stdin unavailable to the script itself)
+# - arg: pass code as a command-line argument
 
 [runtimes.go]
 command = "go run"
-execution_mode = "file"  # Go requires file-based execution
-
-[runtimes.golang]
-command = "go run"
 execution_mode = "file"
+
+[runtimes.jq]
+command = "jq"
+execution_mode = "arg"  # jq's filter is a CLI argument, not read from stdin
 
 [runtimes.mq]
 command = "mq"
 execution_mode = "arg"  # mq uses query as argument
 ```
 
+Use `execution_mode = "stdin"` only when a command needs the code piped in literally (e.g. `psql`, `redis-cli`) — the task script then can't also read from the terminal.
+
 You can also mix both formats:
 
 ```toml
 [runtimes]
-python = "python3"  # Simple format, uses default stdin mode
+python = "python3"  # Simple format, uses default file mode
 
 [runtimes.go]       # Detailed format with custom execution mode
 command = "go run"
@@ -218,6 +288,12 @@ mq-task -f tasks.md Build
 mq-task run Build
 mq-task run --file tasks.md Build
 ```
+
+`default_task` (top-level, outside `[runtimes]`) sets which task runs when `mq-task` is invoked with no task name — see [Aliases and the default task](#aliases-and-the-default-task).
+
+## Exit codes
+
+`mq-task` exits with the same code the task's process exited with, so it composes correctly with `&&`, CI, and git hooks.
 
 ## License
 

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -5,15 +5,7 @@
       <stop offset="100%" style="stop-color:#61AFEF" />
     </linearGradient>
   </defs>
-  <!-- Checklist rows: two done tasks, one pending -->
-  <rect x="20" y="17" width="16" height="16" rx="4" fill="none" stroke="url(#flowGradient)" stroke-width="5" />
-  <path d="M23 25 L27 29 L33 20" fill="none" stroke="url(#flowGradient)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
-  <line x1="46" y1="25" x2="80" y2="25" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" />
-
-  <rect x="20" y="42" width="16" height="16" rx="4" fill="none" stroke="url(#flowGradient)" stroke-width="5" />
-  <path d="M23 50 L27 54 L33 45" fill="none" stroke="url(#flowGradient)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
-  <line x1="46" y1="50" x2="80" y2="50" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" />
-
-  <rect x="20" y="67" width="16" height="16" rx="4" fill="none" stroke="url(#flowGradient)" stroke-width="5" />
-  <line x1="46" y1="75" x2="80" y2="75" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" />
+  <!-- Completed-task badge: rounded card with a centered checkmark -->
+  <rect x="21" y="21" width="58" height="58" rx="14" fill="none" stroke="url(#flowGradient)" stroke-width="7" />
+  <path d="M34 51 L45.5 62.5 L69 34" fill="none" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="flowGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#2B5773" />
+      <stop offset="100%" style="stop-color:#61AFEF" />
+    </linearGradient>
+  </defs>
+  <!-- Checklist rows: two done tasks, one pending -->
+  <rect x="20" y="17" width="16" height="16" rx="4" fill="none" stroke="url(#flowGradient)" stroke-width="5" />
+  <path d="M23 25 L27 29 L33 20" fill="none" stroke="url(#flowGradient)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
+  <line x1="46" y1="25" x2="80" y2="25" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" />
+
+  <rect x="20" y="42" width="16" height="16" rx="4" fill="none" stroke="url(#flowGradient)" stroke-width="5" />
+  <path d="M23 50 L27 54 L33 45" fill="none" stroke="url(#flowGradient)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
+  <line x1="46" y1="50" x2="80" y2="50" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" />
+
+  <rect x="20" y="67" width="16" height="16" rx="4" fill="none" stroke="url(#flowGradient)" stroke-width="5" />
+  <line x1="46" y1="75" x2="80" y2="75" stroke="url(#flowGradient)" stroke-width="8" stroke-linecap="round" />
+</svg>

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,12 +75,16 @@ pub struct Config {
     /// Runtime mappings: language -> command or detailed config
     #[serde(default = "default_runtimes")]
     pub runtimes: HashMap<String, RuntimeConfig>,
+    /// Task run when mq-task is invoked with no task name and no subcommand
+    #[serde(default)]
+    pub default_task: Option<String>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             runtimes: default_runtimes(),
+            default_task: None,
         }
     }
 }
@@ -166,35 +170,37 @@ impl Config {
 fn default_runtimes() -> HashMap<String, RuntimeConfig> {
     let mut runtimes = HashMap::new();
 
-    // Languages with stdin execution mode (default)
+    // File mode (default) keeps the child's real stdin free for interactive
+    // prompts like `read`; Stdin mode consumes it to deliver the script.
+    for (lang, command) in [
+        ("bash", "bash"),
+        ("sh", "sh"),
+        ("python", "python3"),
+        ("ruby", "ruby"),
+        ("node", "node"),
+        ("javascript", "node"),
+        ("js", "node"),
+        ("php", "php"),
+        ("perl", "perl"),
+    ] {
+        runtimes.insert(
+            lang.to_string(),
+            RuntimeConfig::Detailed {
+                command: command.to_string(),
+                execution_mode: ExecutionMode::File,
+            },
+        );
+    }
+
+    // jq's filter is passed as a command-line argument, not read from stdin
+    // (stdin is reserved for the JSON data), so it uses arg mode.
     runtimes.insert(
-        "bash".to_string(),
-        RuntimeConfig::Simple("bash".to_string()),
+        "jq".to_string(),
+        RuntimeConfig::Detailed {
+            command: "jq".to_string(),
+            execution_mode: ExecutionMode::Arg,
+        },
     );
-    runtimes.insert("sh".to_string(), RuntimeConfig::Simple("sh".to_string()));
-    runtimes.insert(
-        "python".to_string(),
-        RuntimeConfig::Simple("python3".to_string()),
-    );
-    runtimes.insert(
-        "ruby".to_string(),
-        RuntimeConfig::Simple("ruby".to_string()),
-    );
-    runtimes.insert(
-        "node".to_string(),
-        RuntimeConfig::Simple("node".to_string()),
-    );
-    runtimes.insert(
-        "javascript".to_string(),
-        RuntimeConfig::Simple("node".to_string()),
-    );
-    runtimes.insert("js".to_string(), RuntimeConfig::Simple("node".to_string()));
-    runtimes.insert("php".to_string(), RuntimeConfig::Simple("php".to_string()));
-    runtimes.insert(
-        "perl".to_string(),
-        RuntimeConfig::Simple("perl".to_string()),
-    );
-    runtimes.insert("jq".to_string(), RuntimeConfig::Simple("jq".to_string()));
 
     // Go requires file-based execution
     runtimes.insert(
@@ -239,9 +245,10 @@ mod tests {
     #[test]
     fn test_execution_modes() {
         let config = Config::default();
-        // Test default execution mode (stdin)
-        assert_eq!(config.get_execution_mode("bash"), ExecutionMode::Stdin);
-        assert_eq!(config.get_execution_mode("python"), ExecutionMode::Stdin);
+        // Interpreted languages default to file-based execution so task
+        // scripts keep interactive access to the real stdin.
+        assert_eq!(config.get_execution_mode("bash"), ExecutionMode::File);
+        assert_eq!(config.get_execution_mode("python"), ExecutionMode::File);
 
         // Test file-based execution mode
         assert_eq!(config.get_execution_mode("go"), ExecutionMode::File);
@@ -249,6 +256,7 @@ mod tests {
 
         // Test arg-based execution mode
         assert_eq!(config.get_execution_mode("mq"), ExecutionMode::Arg);
+        assert_eq!(config.get_execution_mode("jq"), ExecutionMode::Arg);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,4 +43,12 @@ pub enum Error {
     /// Circular dependency detected
     #[error("Circular dependency detected involving task: {0}")]
     CircularDependency(String),
+
+    /// Task process exited with a non-zero status
+    #[error("Task exited with status code {0}")]
+    ExecutionFailed(i32),
+
+    /// A required task parameter was not provided
+    #[error("Missing required parameter '{0}' for task '{1}'")]
+    MissingParameter(String, String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@
 
 use clap::{Parser, Subcommand};
 use colored::*;
-use miette::{IntoDiagnostic, Result};
 use std::path::PathBuf;
+use std::process::ExitCode;
 
-use mq_task::{Config, ExecutionMode, Runner};
+use mq_task::{Config, ExecutionMode, Error, Result, Runner};
 
 const DEFAULT_TASKS_FILE: &str = "README.md";
 
@@ -45,6 +45,10 @@ struct Cli {
     /// Arguments to pass to the task (use -- to separate: mq_task task -- arg1 arg2)
     #[arg(last = true)]
     args: Vec<String>,
+
+    /// Include private tasks (name starts with `_` or `meta` has private = true) when listing
+    #[arg(short, long)]
+    all: bool,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -99,6 +103,10 @@ enum Commands {
         /// Filter code blocks by language (e.g., bash, python, go)
         #[arg(long, value_name = "LANG")]
         lang: Option<String>,
+
+        /// Include private tasks (name starts with `_` or `meta` has private = true)
+        #[arg(short, long)]
+        all: bool,
     },
 
     /// Interactively select and run a task using TUI
@@ -118,6 +126,10 @@ enum Commands {
         /// Show what would be executed without actually running it
         #[arg(long)]
         dry_run: bool,
+
+        /// Include private tasks (name starts with `_` or `meta` has private = true)
+        #[arg(short, long)]
+        all: bool,
     },
 
     /// Generate a sample configuration file
@@ -128,9 +140,23 @@ enum Commands {
     },
 }
 
-fn main() -> Result<()> {
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
+    match dispatch(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            let code = match &err {
+                Error::ExecutionFailed(code) => *code,
+                _ => 1,
+            };
+            eprintln!("{} {}", "Error:".red().bold(), err);
+            ExitCode::from(code.clamp(0, 255) as u8)
+        }
+    }
+}
+
+fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Some(Commands::Run {
             file,
@@ -142,13 +168,19 @@ fn main() -> Result<()> {
             dry_run,
             args,
         }) => run_task(file, task, config, runtime, execution_mode, lang, dry_run, args)?,
-        Some(Commands::List { file, config, lang }) => list_tasks(file, config, lang)?,
+        Some(Commands::List {
+            file,
+            config,
+            lang,
+            all,
+        }) => list_tasks(file, config, lang, all)?,
         Some(Commands::Tui {
             file,
             config,
             lang,
             dry_run,
-        }) => run_tui(file, config, lang, dry_run)?,
+            all,
+        }) => run_tui(file, config, lang, dry_run, all)?,
         Some(Commands::Init { output }) => init_config(output)?,
         None => {
             // If no subcommand, check if task is provided
@@ -164,8 +196,22 @@ fn main() -> Result<()> {
                     cli.args,
                 )?;
             } else {
-                // No task provided, list available tasks
-                list_tasks(cli.file, cli.config, cli.lang)?;
+                // No task given: fall back to the configured default task, if any
+                let config = load_config(cli.config.clone())?;
+                if let Some(default_task) = config.default_task.clone() {
+                    run_task(
+                        cli.file,
+                        default_task,
+                        cli.config,
+                        cli.runtime,
+                        cli.execution_mode,
+                        cli.lang,
+                        cli.dry_run,
+                        cli.args,
+                    )?;
+                } else {
+                    list_tasks(cli.file, cli.config, cli.lang, cli.all)?;
+                }
             }
         }
     }
@@ -189,16 +235,14 @@ fn run_task(
 
     // Parse execution mode if specified
     let exec_mode = if let Some(mode_str) = execution_mode {
-        Some(ExecutionMode::try_from(mode_str.as_str()).into_diagnostic()?)
+        Some(ExecutionMode::try_from(mode_str.as_str())?)
     } else {
         None
     };
 
     // Apply runtime overrides
     if !runtime_overrides.is_empty() {
-        config
-            .apply_runtime_overrides(&runtime_overrides, exec_mode)
-            .into_diagnostic()?;
+        config.apply_runtime_overrides(&runtime_overrides, exec_mode)?;
     }
 
     let mut runner = Runner::new(config);
@@ -206,9 +250,7 @@ fn run_task(
 
     println!("Running task: {}\n", task_name);
 
-    runner
-        .run_task_with_lang_filter(&markdown_path, &task_name, &args, lang_filter.as_deref())
-        .into_diagnostic()?;
+    runner.run_task_with_lang_filter(&markdown_path, &task_name, &args, lang_filter.as_deref())?;
 
     Ok(())
 }
@@ -219,9 +261,10 @@ fn run_tui(
     config_path: Option<PathBuf>,
     lang_filter: Option<String>,
     dry_run: bool,
+    show_all: bool,
 ) -> Result<()> {
     let config = load_config(config_path)?;
-    mq_task::tui::run_tui(markdown_path, config, lang_filter, dry_run).into_diagnostic()?;
+    mq_task::tui::run_tui(markdown_path, config, lang_filter, dry_run, show_all)?;
     Ok(())
 }
 
@@ -230,23 +273,23 @@ fn list_tasks(
     markdown_path: PathBuf,
     config_path: Option<PathBuf>,
     lang_filter: Option<String>,
+    show_all: bool,
 ) -> Result<()> {
     let config = load_config(config_path)?;
     let mut runner = Runner::new(config);
 
-    let sections = runner
-        .list_task_sections(&markdown_path)
-        .into_diagnostic()?;
+    let sections = runner.list_task_sections(&markdown_path)?;
 
-    // Filter sections by language if specified
-    let filtered_sections: Vec<_> = if let Some(ref lang) = lang_filter {
-        sections
-            .into_iter()
-            .filter(|section| section.codes.iter().any(|code| code.lang == *lang))
-            .collect()
-    } else {
-        sections
-    };
+    // Filter sections by language if specified, and hide private tasks unless --all
+    let filtered_sections: Vec<_> = sections
+        .into_iter()
+        .filter(|section| show_all || !section.private)
+        .filter(|section| {
+            lang_filter
+                .as_ref()
+                .is_none_or(|lang| section.codes.iter().any(|code| code.lang == *lang))
+        })
+        .collect();
 
     if filtered_sections.is_empty() {
         if let Some(ref lang) = lang_filter {
@@ -308,28 +351,34 @@ fn list_tasks(
             String::new()
         };
 
+        let title_display = if section.aliases.is_empty() {
+            section.title.green().bold().to_string()
+        } else {
+            format!(
+                "{} {}",
+                section.title.green().bold(),
+                format!("({})", section.aliases.join(", ")).bright_black()
+            )
+        };
+
         if let Some(desc) = section.description {
             let trimmed = desc.trim();
             if !trimmed.is_empty() {
                 output.push_str(&format!(
                     "  {}{} {}\n",
-                    section.title.green().bold(),
+                    title_display,
                     lang_info,
                     format!("- {}", trimmed).bright_black()
                 ));
             } else {
                 output.push_str(&format!(
                     "  {}{}\n",
-                    section.title.green().bold(),
+                    title_display,
                     lang_info
                 ));
             }
         } else {
-            output.push_str(&format!(
-                "  {}{}\n",
-                section.title.green().bold(),
-                lang_info
-            ));
+            output.push_str(&format!("  {}{}\n", title_display, lang_info));
         }
     }
 
@@ -341,16 +390,17 @@ fn list_tasks(
 /// Initialize configuration file
 fn init_config(output_path: PathBuf) -> Result<()> {
     if output_path.exists() {
-        return Err(miette::miette!(
+        return Err(Error::Config(format!(
             "Configuration file already exists: {}",
             output_path.display()
-        ));
+        )));
     }
 
     let config = Config::default();
-    let toml = toml::to_string_pretty(&config).into_diagnostic()?;
+    let toml = toml::to_string_pretty(&config)
+        .map_err(|e| Error::Config(format!("Failed to serialize configuration: {}", e)))?;
 
-    std::fs::write(&output_path, toml).into_diagnostic()?;
+    std::fs::write(&output_path, toml)?;
     println!("Configuration file created: {}", output_path.display());
 
     Ok(())
@@ -359,7 +409,7 @@ fn init_config(output_path: PathBuf) -> Result<()> {
 /// Load configuration from file or use default
 fn load_config(config_path: Option<PathBuf>) -> Result<Config> {
     let config = if let Some(path) = config_path {
-        Config::from_file(&path).into_diagnostic()?
+        Config::from_file(&path)?
     } else {
         Config::default()
     };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -26,6 +26,35 @@ pub struct CodeBlock {
 struct TaskMeta {
     #[serde(default)]
     depends: Vec<String>,
+    #[serde(default)]
+    params: Vec<String>,
+    #[serde(default)]
+    alias: Vec<String>,
+    #[serde(default)]
+    private: bool,
+}
+
+/// A named task parameter, e.g. `params = ["env=staging", "verbose"]`.
+/// A bare name is required; `name=value` supplies a default.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ParamDef {
+    pub name: String,
+    pub default: Option<String>,
+}
+
+impl ParamDef {
+    fn parse(raw: &str) -> Self {
+        match raw.split_once('=') {
+            Some((name, default)) => ParamDef {
+                name: name.trim().to_string(),
+                default: Some(default.trim().to_string()),
+            },
+            None => ParamDef {
+                name: raw.trim().to_string(),
+                default: None,
+            },
+        }
+    }
 }
 
 /// Represents a section with its code blocks
@@ -40,6 +69,15 @@ pub struct Section {
     /// Task names this section depends on (declared in a `meta` code block)
     #[serde(default)]
     pub depends: Vec<String>,
+    /// Named parameters this task accepts (declared in a `meta` code block)
+    #[serde(default)]
+    pub params: Vec<ParamDef>,
+    /// Alternate names this task can be run by (declared in a `meta` code block)
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    /// Hidden from `list`/`tui` output; set via `meta` or a `_`-prefixed title
+    #[serde(default)]
+    pub private: bool,
 }
 
 /// Task runner that executes code blocks in Markdown sections
@@ -123,12 +161,14 @@ impl Runner {
             })
             .unwrap_or_else(|| Ok(Vec::new()))?;
 
-        let depends = all_codes
+        let meta = all_codes
             .iter()
             .find(|c| c.lang == "meta")
             .and_then(|c| toml::from_str::<TaskMeta>(&c.code).ok())
-            .map(|m| m.depends)
             .unwrap_or_default();
+
+        let params = meta.params.iter().map(|p| ParamDef::parse(p)).collect();
+        let private = meta.private || title.starts_with('_');
 
         let codes: Vec<CodeBlock> = all_codes.into_iter().filter(|c| c.lang != "meta").collect();
 
@@ -141,7 +181,10 @@ impl Runner {
             title,
             codes,
             description,
-            depends,
+            depends: meta.depends,
+            params,
+            aliases: meta.alias,
+            private,
         })
     }
 
@@ -174,7 +217,9 @@ impl Runner {
     }
 
     pub fn find_section<'a>(&self, sections: &'a [Section], title: &str) -> Option<&'a Section> {
-        sections.iter().find(|s| s.title == title)
+        sections
+            .iter()
+            .find(|s| s.title == title || s.aliases.iter().any(|a| a == title))
     }
 
     fn resolve_execution_order<'a>(
@@ -236,6 +281,8 @@ impl Runner {
         args: &[String],
         lang_filter: Option<&str>,
     ) -> Result<()> {
+        let param_env = Self::bind_params(&section.params, args, &section.title)?;
+
         for code_block in &section.codes {
             if code_block.lang.is_empty() {
                 continue;
@@ -248,10 +295,55 @@ impl Runner {
                 continue;
             }
 
-            self.execute_code_with_args(&code_block.lang, &code_block.code, args)?;
+            self.execute_code_with_params(&code_block.lang, &code_block.code, args, &param_env)?;
         }
 
         Ok(())
+    }
+
+    /// Bind declared params to CLI args: `name=value` binds by name, the
+    /// rest fill remaining params positionally, then defaults. Returns
+    /// `MX_PARAM_<NAME>` env pairs; errors if a required param is unbound.
+    fn bind_params(
+        params: &[ParamDef],
+        args: &[String],
+        task_name: &str,
+    ) -> Result<Vec<(String, String)>> {
+        if params.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut named: Vec<(&str, &str)> = Vec::new();
+        let mut positional: Vec<&String> = Vec::new();
+
+        for arg in args {
+            let stripped = arg.strip_prefix("--").unwrap_or(arg);
+            match stripped.split_once('=') {
+                Some((key, value)) if params.iter().any(|p| p.name == key) => {
+                    named.push((key, value));
+                }
+                _ => positional.push(arg),
+            }
+        }
+
+        let mut positional_iter = positional.into_iter();
+        let mut env_vars = Vec::new();
+
+        for param in params {
+            let value = named
+                .iter()
+                .find(|(k, _)| *k == param.name)
+                .map(|(_, v)| v.to_string())
+                .or_else(|| positional_iter.next().cloned())
+                .or_else(|| param.default.clone())
+                .ok_or_else(|| {
+                    Error::MissingParameter(param.name.clone(), task_name.to_string())
+                })?;
+
+            env_vars.push((format!("MX_PARAM_{}", param.name.to_uppercase()), value));
+        }
+
+        Ok(env_vars)
     }
 
     pub fn execute_code(&self, lang: &str, code: &str) -> Result<()> {
@@ -259,6 +351,16 @@ impl Runner {
     }
 
     pub fn execute_code_with_args(&self, lang: &str, code: &str, args: &[String]) -> Result<()> {
+        self.execute_code_with_params(lang, code, args, &[])
+    }
+
+    fn execute_code_with_params(
+        &self,
+        lang: &str,
+        code: &str,
+        args: &[String],
+        param_env: &[(String, String)],
+    ) -> Result<()> {
         let runtime = self
             .config
             .get_runtime(lang)
@@ -278,17 +380,33 @@ impl Runner {
             } else {
                 String::new()
             };
+            let params_line = if !param_env.is_empty() {
+                format!(
+                    "\n[dry-run] params: {}",
+                    param_env
+                        .iter()
+                        .map(|(k, v)| format!("{}={}", k, v))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                )
+            } else {
+                String::new()
+            };
             println!(
-                "[dry-run] lang: {}\n[dry-run] runtime: {}\n[dry-run] code:\n{}{}",
-                lang, runtime, code, args_line
+                "[dry-run] lang: {}\n[dry-run] runtime: {}\n[dry-run] code:\n{}{}{}",
+                lang, runtime, code, args_line, params_line
             );
             return Ok(());
         }
 
         match execution_mode {
-            ExecutionMode::File => self.execute_code_with_file_and_args(lang, code, &parts, args),
-            ExecutionMode::Arg => self.execute_code_with_arg_mode(code, &parts, args),
-            ExecutionMode::Stdin => self.execute_code_with_stdin_and_args(code, &parts, args),
+            ExecutionMode::File => {
+                self.execute_code_with_file_and_args(lang, code, &parts, args, param_env)
+            }
+            ExecutionMode::Arg => self.execute_code_with_arg_mode(code, &parts, args, param_env),
+            ExecutionMode::Stdin => {
+                self.execute_code_with_stdin_and_args(code, &parts, args, param_env)
+            }
         }
     }
 
@@ -297,6 +415,7 @@ impl Runner {
         code: &str,
         parts: &[&str],
         task_args: &[String],
+        param_env: &[(String, String)],
     ) -> Result<()> {
         let cmd = parts[0];
         let args = &parts[1..];
@@ -307,7 +426,7 @@ impl Runner {
             .stdin(Stdio::piped())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            .envs(Self::prepare_env_vars(task_args))
+            .envs(Self::prepare_env_vars(task_args, param_env))
             .spawn()
             .map_err(|e| Error::Execution(format!("Failed to spawn process: {}", e)))?;
 
@@ -325,7 +444,7 @@ impl Runner {
             .map_err(|e| Error::Execution(format!("Failed to wait for process: {}", e)))?;
 
         if !status.success() {
-            return Err(Error::Execution("Execution failed".to_string()));
+            return Err(Error::ExecutionFailed(status.code().unwrap_or(1)));
         }
 
         Ok(())
@@ -336,36 +455,24 @@ impl Runner {
         code: &str,
         parts: &[&str],
         task_args: &[String],
+        param_env: &[(String, String)],
     ) -> Result<()> {
         let cmd = parts[0];
         // Append code as an argument to the command
         let mut args: Vec<&str> = parts[1..].to_vec();
         args.push(code);
 
-        // Use inherit() for stdout/stderr to preserve TTY and colors
-        let mut child = Command::new(cmd)
+        // Use inherit() for stdin/stdout/stderr to preserve TTY, colors, and interactivity
+        let status = Command::new(cmd)
             .args(args)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            .envs(Self::prepare_env_vars(task_args))
-            .spawn()
+            .envs(Self::prepare_env_vars(task_args, param_env))
+            .status()
             .map_err(|e| Error::Execution(format!("Failed to spawn process: {}", e)))?;
 
-        // Write code to stdin
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(code.as_bytes())
-                .map_err(|e| Error::Execution(format!("Failed to write to stdin: {}", e)))?;
-            drop(stdin);
-        }
-
-        // Wait for completion
-        let status = child
-            .wait()
-            .map_err(|e| Error::Execution(format!("Failed to wait for process: {}", e)))?;
-
         if !status.success() {
-            return Err(Error::Execution("Execution failed".to_string()));
+            return Err(Error::ExecutionFailed(status.code().unwrap_or(1)));
         }
 
         Ok(())
@@ -377,6 +484,7 @@ impl Runner {
         code: &str,
         parts: &[&str],
         task_args: &[String],
+        param_env: &[(String, String)],
     ) -> Result<()> {
         use std::env;
 
@@ -411,7 +519,7 @@ impl Runner {
             .arg(&temp_file)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            .envs(Self::prepare_env_vars(task_args))
+            .envs(Self::prepare_env_vars(task_args, param_env))
             .status()
             .map_err(|e| Error::Execution(format!("Failed to execute {}: {}", lang, e)))?;
 
@@ -419,20 +527,22 @@ impl Runner {
         fs::remove_file(&temp_file).ok();
 
         if !status.success() {
-            Err(Error::Execution(format!("{} execution failed", lang)))
+            Err(Error::ExecutionFailed(status.code().unwrap_or(1)))
         } else {
             Ok(())
         }
     }
 
-    /// Prepare environment variables from task arguments
-    fn prepare_env_vars(args: &[String]) -> Vec<(String, String)> {
+    /// Prepare environment variables from task arguments and bound named parameters
+    fn prepare_env_vars(args: &[String], param_env: &[(String, String)]) -> Vec<(String, String)> {
         let mut env_vars = Vec::new();
 
         // Set MX_ARGS with all arguments joined by space
         if !args.is_empty() {
             env_vars.push(("MX_ARGS".to_string(), args.join(" ")));
         }
+
+        env_vars.extend(param_env.iter().cloned());
 
         // Set individual arguments as MX_ARG_0, MX_ARG_1, etc.
         for (i, arg) in args.iter().enumerate() {
@@ -469,9 +579,14 @@ impl Runner {
         let sections = self.extract_sections(&markdown)?;
 
         let execution_order = self.resolve_execution_order(&sections, task_name)?;
+        // Resolve alias to canonical title for the is_dep check below.
+        let primary_title = self
+            .find_section(&sections, task_name)
+            .map(|s| s.title.clone())
+            .unwrap_or_else(|| task_name.to_string());
 
         for section in execution_order {
-            let is_dep = section.title != task_name;
+            let is_dep = section.title != primary_title;
             if is_dep {
                 println!("Running dependency: {}\n", section.title);
             }
@@ -576,6 +691,9 @@ print("world")
             ],
             description: None,
             depends: vec![],
+            params: vec![],
+            aliases: vec![],
+            private: false,
         };
 
         let runner = Runner::with_default_config();
@@ -670,18 +788,27 @@ echo "testing"
                 codes: vec![],
                 description: None,
                 depends: vec![],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
             Section {
                 title: "lint".to_string(),
                 codes: vec![],
                 description: None,
                 depends: vec!["format".to_string()],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
             Section {
                 title: "test".to_string(),
                 codes: vec![],
                 description: None,
                 depends: vec!["lint".to_string()],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
         ];
 
@@ -702,12 +829,18 @@ echo "testing"
                 codes: vec![],
                 description: None,
                 depends: vec!["b".to_string()],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
             Section {
                 title: "b".to_string(),
                 codes: vec![],
                 description: None,
                 depends: vec!["a".to_string()],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
         ];
 
@@ -724,18 +857,27 @@ echo "testing"
                 codes: vec![],
                 description: None,
                 depends: vec![],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
             Section {
                 title: "lint".to_string(),
                 codes: vec![],
                 description: None,
                 depends: vec!["format".to_string()],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
             Section {
                 title: "test".to_string(),
                 codes: vec![],
                 description: None,
                 depends: vec!["format".to_string(), "lint".to_string()],
+                params: vec![],
+                aliases: vec![],
+                private: false,
             },
         ];
 
@@ -747,5 +889,68 @@ echo "testing"
         assert_eq!(order[0].title, "format");
         assert_eq!(order[1].title, "lint");
         assert_eq!(order[2].title, "test");
+    }
+
+    #[test]
+    fn test_params_parsed_from_meta_block() {
+        let markdown = r#"# Title
+
+## deploy
+
+```meta
+params = ["env=staging", "verbose"]
+```
+
+```bash
+echo "deploying"
+```
+"#;
+
+        let mut runner = Runner::with_default_config();
+        let sections = runner.extract_sections(markdown).unwrap();
+
+        let deploy = sections.iter().find(|s| s.title == "deploy").unwrap();
+        assert_eq!(deploy.params.len(), 2);
+        assert_eq!(deploy.params[0].name, "env");
+        assert_eq!(deploy.params[0].default, Some("staging".to_string()));
+        assert_eq!(deploy.params[1].name, "verbose");
+        assert_eq!(deploy.params[1].default, None);
+    }
+
+    #[test]
+    fn test_bind_params_uses_named_positional_and_default() {
+        let params = vec![
+            ParamDef {
+                name: "env".to_string(),
+                default: Some("staging".to_string()),
+            },
+            ParamDef {
+                name: "region".to_string(),
+                default: None,
+            },
+        ];
+
+        // named + positional
+        let bound = Runner::bind_params(
+            &params,
+            &["region=eu".to_string(), "prod".to_string()],
+            "deploy",
+        )
+        .unwrap();
+        assert_eq!(
+            bound,
+            vec![
+                ("MX_PARAM_ENV".to_string(), "prod".to_string()),
+                ("MX_PARAM_REGION".to_string(), "eu".to_string()),
+            ]
+        );
+
+        // falls back to default when unset
+        let bound = Runner::bind_params(&params, &["region=eu".to_string()], "deploy").unwrap();
+        assert_eq!(bound[0], ("MX_PARAM_ENV".to_string(), "staging".to_string()));
+
+        // missing required param is an error
+        let result = Runner::bind_params(&params, &[], "deploy");
+        assert!(matches!(result, Err(Error::MissingParameter(_, _))));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -78,6 +78,7 @@ pub fn run_tui(
     config: Config,
     lang_filter: Option<String>,
     dry_run: bool,
+    show_all: bool,
 ) -> crate::error::Result<()> {
     let mut runner = Runner::new(config.clone());
     runner.set_dry_run(dry_run);
@@ -86,15 +87,15 @@ pub fn run_tui(
         let mut r = Runner::new(config);
         let raw_sections = r.list_task_sections(&markdown_path)?;
 
-        // Apply language filter if specified
-        if let Some(ref lang) = lang_filter {
-            raw_sections
-                .into_iter()
-                .filter(|s| s.codes.iter().any(|c| c.lang == *lang))
-                .collect()
-        } else {
-            raw_sections
-        }
+        raw_sections
+            .into_iter()
+            .filter(|s| show_all || !s.private)
+            .filter(|s| {
+                lang_filter
+                    .as_ref()
+                    .is_none_or(|lang| s.codes.iter().any(|c| c.lang == *lang))
+            })
+            .collect()
     };
 
     // Setup terminal


### PR DESCRIPTION
- Propagate a task's real process exit code instead of always exiting 1
- Default interpreted-language runtimes to file-based execution so
  scripts keep an interactive stdin (read, sudo -S, etc. now work);
  jq now defaults to arg mode since its filter is a CLI argument
- Add named task parameters with defaults via a `params` meta field,
  bound from named/positional CLI args and exposed as MX_PARAM_* env vars
- Add default_task config option, task aliases, and private
  (hidden) tasks via meta fields or a `_`-prefixed title
